### PR TITLE
Addressed issue where class import does not conform to Clojure 1.10 ns spec

### DIFF
--- a/src/hitchhiker/tree/core.cljc
+++ b/src/hitchhiker/tree/core.cljc
@@ -14,7 +14,7 @@
                    [java.util Arrays Collections]))
   #?(:cljs (:require-macros [cljs.core.async.macros :refer [go]]
                             [hitchhiker.tree.core :refer [go-try <? <?resolve]]))
-  #?(:clj (:import [clojure.lang.PersistentTreeMap$BlackVal])))
+  #?(:clj (:import clojure.lang.PersistentTreeMap$BlackVal)))
 
 
 ;; cljs macro environment


### PR DESCRIPTION
To replicate the issue, switch to a 1.10 (rc-5 at this point) and use the hitchhiker.tree.core ns:

Clojure 1.10.0-RC5
user=> (use 'hitchhiker.tree.core)
Syntax error macroexpanding clojure.core/ns at (core.cljc:1:1).
() - failed: Insufficient input at: [:ns-clauses :import :classes :package-list :classes] spec: :clojure.core.specs.alpha/package-list
[clojure.lang.PersistentTreeMap$BlackVal] - failed: simple-symbol? at: [:ns-clauses :import :classes :class] spec: :clojure.core.specs.alpha/import-list

Single class imports don't require vectors, although this used to work in 1.9 (obviously!)