### PR TITLE
Tracing GC for konserve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ pom.xml.asc
 *.swo
 *.swn
 *~
+/.idea
+*.iml
+profiles.clj
+/scripts

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [com.taoensso/carmine "2.12.2" :scope "provided"]
                  [org.clojure/core.rrb-vector "0.0.14"]
                  [org.clojure/core.cache "0.7.2"]
-                 [io.replikativ/konserve "0.5.1"]]
+                 [io.replikativ/konserve "0.6.0-SNAPSHOT"]]
   :aliases {"bench" ["with-profile" "profiling" "run" "-m" "hitchhiker.bench"]}
   :jvm-opts ["-server" "-Xmx3700m" "-Xms3700m"]
   :profiles {:test
@@ -42,7 +42,7 @@
                 :compiler {:main hitchhiker.tree.core
                            :asset-path "js/out"
                            :output-to "resources/public/js/core.js"
-                           :output-dir "resources/public/js/out" }}
+                           :output-dir "resources/public/js/out"}}
                ;; inspired by datascript project.clj
                {:id "test"
                 :source-paths ["src" "test"]

--- a/src/hitchhiker/tree.cljc
+++ b/src/hitchhiker/tree.cljc
@@ -81,6 +81,9 @@
            :storage-addr (async/promise-chan)
            :*last-key-cache (cache)))
 
+  (-raw-address [this]
+    (some-> storage-addr (async/poll!) (n/-raw-address)))
+
   n/INode
   (-last-key [this]
     (<-cache *last-key-cache
@@ -171,6 +174,9 @@
     (assoc this
            :storage-addr (async/promise-chan)
            :*last-key-cache (cache)))
+
+  (-raw-address [_]
+    (some-> storage-addr (async/poll!) (n/-raw-address)))
 
   n/INode
   (-last-key [this]

--- a/src/hitchhiker/tree/bootstrap/konserve.cljc
+++ b/src/hitchhiker/tree/bootstrap/konserve.cljc
@@ -58,7 +58,8 @@
 
   Adds a (hexadecimal) timestamp in milliseconds to the start of the
   key; this is so the GC can properly delete keys that don't exist in
-  the tree anymore"
+  the tree anymore, but also skips keys that were added after the GC
+  process begins."
   [uuid]
   (format "%016x.%s" (System/currentTimeMillis) uuid))
 

--- a/src/hitchhiker/tree/bootstrap/konserve.cljc
+++ b/src/hitchhiker/tree/bootstrap/konserve.cljc
@@ -53,6 +53,15 @@
   [key]
   (ha/promise-chan key))
 
+(defn create-id
+  "Generate a storage ID from a content UUID.
+
+  Adds a (hexadecimal) timestamp in milliseconds to the start of the
+  key; this is so the GC can properly delete keys that don't exist in
+  the tree anymore"
+  [uuid]
+  (format "%016x.%s" (System/currentTimeMillis) uuid))
+
 (defrecord KonserveAddr [store last-key konserve-key storage-addr]
   n/INode
   (-last-key [_] last-key)
@@ -90,7 +99,7 @@
     (ha/go-try
      (swap! session update-in [:writes] inc)
      (let [pnode (encode node)
-           id (h/uuid pnode)
+           id (create-id (h/uuid pnode))
            ch (k/assoc-in store [id] node)]
        (ha/<? ch)
        (konserve-addr store

--- a/src/hitchhiker/tree/bootstrap/redis.clj
+++ b/src/hitchhiker/tree/bootstrap/redis.clj
@@ -178,6 +178,8 @@
     (ha/go-try (-> (totally-fetch redis-key)
                    (assoc :storage-addr (synthesize-storage-addr redis-key)))))
 
+  (-raw-address [_] redis-key)
+
   n/INode
   (-last-key [_] last-key))
 

--- a/src/hitchhiker/tree/node.cljc
+++ b/src/hitchhiker/tree/node.cljc
@@ -10,7 +10,8 @@
 (defprotocol IAddress
   (-dirty? [node] "Returns true if this should be flushed")
   (-dirty! [node] "Marks a node as being dirty if it was clean")
-  (-resolve-chan [node] "Returns the INode version of this node; could trigger IO, returns a core.async promise-chan"))
+  (-resolve-chan [node] "Returns the INode version of this node; could trigger IO, returns a core.async promise-chan")
+  (-raw-address [node] "Returns the underlying storage's raw address; returns nil if no storage address."))
 
 (defprotocol INode
   (-last-key [node] "Returns the rightmost key of the node")

--- a/src/hitchhiker/tree/tracing_gc.cljc
+++ b/src/hitchhiker/tree/tracing_gc.cljc
@@ -1,6 +1,5 @@
 (ns hitchhiker.tree.tracing-gc
   (:require [clojure.core.async :as async]
-            [clojure.tools.logging :as log]
             [hitchhiker.tree :as hh]
             [hitchhiker.tree.node :as n]
             [hitchhiker.tree.utils.async :as ha]))
@@ -32,12 +31,9 @@
                      (when-let [root (first roots)]
                        (loop [nodes [root]]
                          (when-let [node (first nodes)]
-                           (log/debug :task ::trace-gc! :phase :marking :visiting-node (async/poll! (:storage-addr node)))
                            (let [node (if (hh/resolved? node)
                                         node
-                                        (do-<! (do
-                                                 (log/debug :task ::trace-gc! :phase :marking :resolve-node node)
-                                                 (n/-resolve-chan node))))
+                                        (do-<! (n/-resolve-chan node)))
                                  nodes (if (hh/index-node? node)
                                          (into (subvec nodes 1) (:children node))
                                          (subvec nodes 1))]

--- a/src/hitchhiker/tree/tracing_gc.cljc
+++ b/src/hitchhiker/tree/tracing_gc.cljc
@@ -34,10 +34,9 @@
   "Walk all storage addresses from seq all-addresses, calling delete-fn on
   each key that for which accept-fn returns true, AND is not contained
   in the set addresses."
-  [addresses accept-fn all-addresses delete-fn]
+  [addresses all-addresses delete-fn]
   (loop [addrs all-addresses]
     (when-let [address (first addrs)]
-      (when (and (accept-fn address)
-                 (not (contains? addresses address)))
+      (when (not (contains? addresses address))
         (delete-fn address))
       (recur (rest addrs)))))

--- a/src/hitchhiker/tree/tracing_gc.cljc
+++ b/src/hitchhiker/tree/tracing_gc.cljc
@@ -37,7 +37,7 @@
                                  nodes (if (hh/index-node? node)
                                          (into (subvec nodes 1) (:children node))
                                          (subvec nodes 1))]
-                             (when-let [address (async/poll! (:storage-addr node))]
+                             (when-let [address (n/-raw-address node)]
                                (async/<! (observe-addr! gc-scratch address)))
                              (recur nodes))))
                        (recur (rest roots))))]

--- a/src/hitchhiker/tree/tracing_gc.cljc
+++ b/src/hitchhiker/tree/tracing_gc.cljc
@@ -1,0 +1,54 @@
+(ns hitchhiker.tree.tracing-gc
+  (:require [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
+            [hitchhiker.tree :as hh]
+            [hitchhiker.tree.node :as n]
+            [hitchhiker.tree.utils.async :as ha]))
+
+(defprotocol IGCScratch
+  (observe-addr! [this addr] "Marks the given addr as being currently active")
+  (observed? [this addr] "Returns true if the given addr was observed"))
+
+(defmacro do-<!
+  "Force into an async taking call.
+
+  Evaluates to <! when in an async backend.
+  Wraps form in a thread when non-async."
+  [& form]
+  (ha/if-async?
+    `(async/<! ~@form)
+    `(async/<! (async/thread ~@form))))
+
+(defn trace-gc!
+  "Does a tracing GC and frees up all unused keys.
+   This is a simple mark-sweep algorithm.
+
+   gc-scratch should be an instance of IGCScratch
+   gc-roots should be a list of the roots of currently active trees.
+   all-keys should be a core.async channel that will contain every key in storage.
+   delete-fn will be called on every key that should be deleted during the sweep phase. It is expected to return a channel that yields when the item is deleted."
+  [gc-scratch gc-roots all-keys delete-fn]
+  (let [mark-phase (async/go-loop [roots gc-roots]
+                     (when-let [root (first roots)]
+                       (loop [nodes [root]]
+                         (when-let [node (first nodes)]
+                           (log/debug :task ::trace-gc! :phase :marking :visiting-node (async/poll! (:storage-addr node)))
+                           (let [node (if (hh/resolved? node)
+                                        node
+                                        (do-<! (do
+                                                 (log/debug :task ::trace-gc! :phase :marking :resolve-node node)
+                                                 (n/-resolve-chan node))))
+                                 nodes (if (hh/index-node? node)
+                                         (into (subvec nodes 1) (:children node))
+                                         (subvec nodes 1))]
+                             (when-let [address (async/poll! (:storage-addr node))]
+                               (async/<! (observe-addr! gc-scratch address)))
+                             (recur nodes))))
+                       (recur (rest roots))))]
+    (async/go
+      (async/<! mark-phase)
+      (loop []
+        (when-let [address (async/<! all-keys)]
+          (when-not (async/<! (observed? gc-scratch address))
+            (async/<! (delete-fn address)))
+          (recur))))))

--- a/src/hitchhiker/tree/tracing_gc/epoch.cljc
+++ b/src/hitchhiker/tree/tracing_gc/epoch.cljc
@@ -16,19 +16,18 @@
              (compare (.getTime e1) (.getTime e2))
              (compare e1 e2))))
 
-(defn- after-epoch?
+(defn- before-epoch?
   [address epoch]
   (if (and (sequential? address)
            (<= 1 (count address))
            (= (type epoch) (type (first address))))
-    (not (neg? (compare-stamps (first address) epoch)))
-    true))
+    (neg? (compare-stamps (first address) epoch))
+    false))
 
-(defrecord EpochBasedGCScratch [store epoch]
-  gc/IGCScratch
-  (observe-addr! [_ addr]
-    (swap! store conj addr))
-
-  (observed? [_ addr]
-    (or (after-epoch? addr epoch)
-        (contains? @store addr))))
+(defn accept-before-epoch
+  "Return a function that accepts addresses that occur
+  before the given epoch. Addresses that are not a sequential
+  value and don't have a compatible timestamp as the first
+  element are not accepted."
+  [epoch]
+  (fn [address] (before-epoch? address epoch)))

--- a/src/hitchhiker/tree/tracing_gc/epoch.cljc
+++ b/src/hitchhiker/tree/tracing_gc/epoch.cljc
@@ -1,13 +1,6 @@
 (ns hitchhiker.tree.tracing-gc.epoch
-  "A GC scratch implementation that considers timestamped
-  keys, and only considers keys that are marked before some
-  epoch.
-
-  Only recognizes keys that are a vector, and which the first
-  element is comparable to the epoch."
-  (:require [hitchhiker.tree.tracing-gc :as gc]
-            #?(:clj  [clojure.core.async :as async]
-               :cljs [cljs.core.async :as async :include-macros true])))
+  "Utilities for filtering konserve backend addresses
+  by epoch.")
 
 (defn compare-stamps
   [e1 e2]

--- a/src/hitchhiker/tree/tracing_gc/konserve.cljc
+++ b/src/hitchhiker/tree/tracing_gc/konserve.cljc
@@ -1,6 +1,5 @@
 (ns hitchhiker.tree.tracing-gc.konserve
-  (:require [clojure.tools.logging :as log]
-            [hitchhiker.tree.tracing-gc :as gc]
+  (:require [hitchhiker.tree.tracing-gc :as gc]
             [konserve.core :as k]
             #?(:clj  [clojure.core.async :as async]
                :cljs [cljs.core.async :as async :include-macros true])))
@@ -16,13 +15,9 @@
 (defrecord KonserveGCScratch [store epoch]
   gc/IGCScratch
   (observe-addr! [_ addr]
-    (log/debug :task ::gc/observe-addr! :addr addr)
     (k/assoc store addr :marked))
 
   (observed? [_ addr]
     (async/go
-      (log/debug :task ::gc/observed? :phase :begin :addr addr)
-      (let [result (or (within-epoch? addr epoch)
-                       (= :marked (async/<! (k/get store addr))))]
-        (log/debug :task ::gc/observed? :phase :end :addr addr :result result)
-        result))))
+      (or (within-epoch? addr epoch)
+          (= :marked (async/<! (k/get store addr)))))))

--- a/src/hitchhiker/tree/tracing_gc/konserve.cljc
+++ b/src/hitchhiker/tree/tracing_gc/konserve.cljc
@@ -1,15 +1,22 @@
 (ns hitchhiker.tree.tracing-gc.konserve
-  (:require [hitchhiker.tree.tracing-gc :as gc]
-            [konserve.core :as k]
+  (:require [konserve.core :as k]
+            [hitchhiker.tree.tracing-gc :as gc]
             #?(:clj  [clojure.core.async :as async]
                :cljs [cljs.core.async :as async :include-macros true])))
 
-(defn- within-epoch?
+(defn compare-stamps
+  [e1 e2]
+  #?(:clj (compare e1 e2)
+     :cljs (if (and (= js/Date (type e1)) (= js/Date (type e2)))
+             (compare (.getTime e1) (.getTime e2))
+             (compare e1 e2))))
+
+(defn- after-epoch?
   [address epoch]
-  (if-let [addr-ts (some-> (when (string? address)
-                             (re-matches #"([0-9a-f]{16})\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" address))
-                           (second))]
-    (not (pos? (compare addr-ts epoch)))
+  (if (and (vector? address)
+           (= 2 (count address))
+           (= (type epoch) (type (first address))))
+    (not (neg? (compare-stamps (first address) epoch)))
     true))
 
 (defrecord KonserveGCScratch [store epoch]
@@ -19,5 +26,5 @@
 
   (observed? [_ addr]
     (async/go
-      (or (within-epoch? addr epoch)
+      (or (after-epoch? addr epoch)
           (= :marked (async/<! (k/get store addr)))))))

--- a/src/hitchhiker/tree/tracing_gc/konserve.cljc
+++ b/src/hitchhiker/tree/tracing_gc/konserve.cljc
@@ -1,0 +1,28 @@
+(ns hitchhiker.tree.tracing-gc.konserve
+  (:require [clojure.tools.logging :as log]
+            [hitchhiker.tree.tracing-gc :as gc]
+            [konserve.core :as k]
+            #?(:clj  [clojure.core.async :as async]
+               :cljs [cljs.core.async :as async :include-macros true])))
+
+(defn- within-epoch?
+  [address epoch]
+  (if-let [addr-ts (some-> (when (string? address)
+                             (re-matches #"([0-9a-f]{16})\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" address))
+                           (second))]
+    (not (pos? (compare addr-ts epoch)))
+    true))
+
+(defrecord KonserveGCScratch [store epoch]
+  gc/IGCScratch
+  (observe-addr! [_ addr]
+    (log/debug :task ::gc/observe-addr! :addr addr)
+    (k/assoc store addr :marked))
+
+  (observed? [_ addr]
+    (async/go
+      (log/debug :task ::gc/observed? :phase :begin :addr addr)
+      (let [result (or (within-epoch? addr epoch)
+                       (= :marked (async/<! (k/get store addr))))]
+        (log/debug :task ::gc/observed? :phase :end :addr addr :result result)
+        result))))

--- a/src/hitchhiker/tree/utils/plot.clj
+++ b/src/hitchhiker/tree/utils/plot.clj
@@ -28,7 +28,7 @@
   if any. Weights become edge labels unless a label is specified.
   Labels also include attributes when the graph satisfies AttrGraph."
   [g & {:keys [graph-name node-label edge-label]
-        :or {graph-name "graph"} :as opts }]
+        :or {graph-name "graph"} :as opts}]
   (let [d? (directed? g)
         w? (weighted? g)
         a? (attr? g)
@@ -100,7 +100,7 @@
                            (ha/<?? (msg/insert t i i)))
                          (ha/<?? (tree/b-tree (tree/->Config 3 3 2)))
                          (shuffle (range 1 30))))
-           (kons/->KonserveBackend store))))
+           (kons/->KonserveBackend store nil))))
 
 
 (def flushed
@@ -109,7 +109,7 @@
                            (ha/<?? (msg/insert t i i)))
                          (:tree flushed)
                          (shuffle (range -4 -2))))
-           (kons/->KonserveBackend store))))
+           (kons/->KonserveBackend store nil))))
 
 
 
@@ -117,7 +117,7 @@
   ;; TODO double root node?
   (do
     (def store (kons/add-hitchhiker-tree-handlers
-                (kc/ensure-cache (ha/<?? (new-mem-store)))) )
+                (kc/ensure-cache (ha/<?? (new-mem-store)))))
 
 
     ;; insertion
@@ -127,7 +127,7 @@
                                         (ha/<?? (tree/b-tree (tree/->Config 2 2 2)))
                                         (concat (range 1 12)
                                                 #_[0 13 14 -1 15])))
-                          (kons/->KonserveBackend store))))
+                          (kons/->KonserveBackend store nil))))
 
 
     (def flushed (ha/<?? (tree/flush-tree
@@ -135,7 +135,7 @@
                                           (ha/<?? (msg/insert t i i)))
                                         (:tree flushed)
                                         (range 12 14)))
-                          (kons/->KonserveBackend store))))
+                          (kons/->KonserveBackend store nil))))
 
     (view (create-graph store))))
 
@@ -217,8 +217,8 @@
     [k (-> v
            (dissoc :storage-addr :cfg)
            (update :children (fn [cs] (mapv #(dissoc % :storage-addr :store) cs)))
-           (update :op-buf (fn [cs] (mapv #(into {} %) cs)))
-           )]
+           (update :op-buf (fn [cs] (mapv #(into {} %) cs))))]
+
     [k (dissoc v :storage-addr :cfg)]))
 
 

--- a/test/hitchhiker/konserve_test.cljc
+++ b/test/hitchhiker/konserve_test.cljc
@@ -45,7 +45,7 @@
                             (kc/ensure-cache (async/<!
                                               (new-mem-store)
                                               #_(new-fs-store folder)))) ;; always use core.async here!
-                     backend (kons/->KonserveBackend store)
+                     backend (kons/->KonserveBackend store nil)
                      init-tree (ha/<? (ha/reduce< (fn [t i] (msg/insert t i i))
                                                   (ha/<? (core/b-tree (core/->Config 1 3 (- 3 1))))
                                                   (range 1 11)))
@@ -71,7 +71,7 @@
              _ (delete-store folder)
              store (kons/add-hitchhiker-tree-handlers
                     (kc/ensure-cache (async/<!! (new-fs-store folder :config {:fsync false}))))
-             backend (kons/->KonserveBackend store)
+             backend (kons/->KonserveBackend store nil)
              flushed (ha/<?? (core/flush-tree
                               (time (reduce (fn [t i]
                                               (ha/<?? (msg/insert t i i)))

--- a/test/hitchhiker/tree/node/testing.cljc
+++ b/test/hitchhiker/tree/node/testing.cljc
@@ -9,6 +9,7 @@
   (-dirty? [this] false)
   (-dirty! [this] this)
   (-resolve-chan [_] resolve-ch)
+  (-raw-address [_] (n/-raw-address node))
   n/INode
   (-last-key [_] last-key))
 

--- a/test/hitchhiker/tree/tracing_gc_test.clj
+++ b/test/hitchhiker/tree/tracing_gc_test.clj
@@ -33,8 +33,7 @@
                           (vswap! removed conj k)
                           (async/<! (k/dissoc store k))))]
         (gc/sweep! (gc/mark [@tree])
-                   (gce/accept-before-epoch (Date.))
-                   (chan->seq (k/keys store))
+                   (filter (gce/accept-before-epoch (Date.)) (chan->seq (k/keys store)))
                    delete-fn)
         (is (empty? @removed))
         (is (= (set all-storage-keys) (async/<!! (async/into #{} (k/keys store)))))))
@@ -60,8 +59,7 @@
                         (vswap! removed conj k)
                         (async/<!! (k/dissoc store k)))]
         (gc/sweep! (gc/mark [@tree])
-                   (gce/accept-before-epoch (Date.))
-                   (chan->seq (k/keys store))
+                   (filter (gce/accept-before-epoch (Date.)) (chan->seq (k/keys store)))
                    delete-fn)
         (is (seq @removed))
         (is (= live-nodes (async/<!! (async/into #{} (k/keys store))))))

--- a/test/hitchhiker/tree/tracing_gc_test.clj
+++ b/test/hitchhiker/tree/tracing_gc_test.clj
@@ -1,0 +1,64 @@
+(ns hitchhiker.tree.tracing-gc-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [konserve.memory :as mem]
+            [hitchhiker.tree :as tree]
+            [hitchhiker.tree.messaging :as hmsg]
+            [hitchhiker.tree.bootstrap.konserve :as kons]
+            [konserve.core :as k]
+            [hitchhiker.tree.utils.async :as ha]
+            [hitchhiker.tree.tracing-gc :as gc]
+            [hitchhiker.tree.tracing-gc.konserve :as gck]
+            [hitchhiker.tree.node :as n]
+            [konserve.cache :as kc])
+  (:import [java.util Date]))
+
+(deftest test-tracing-gc
+  (let [store (kc/ensure-cache (async/<!! (mem/new-mem-store)))
+        tree (volatile! (tree/b-tree (tree/->Config 2 4 2)))]
+    (dotimes [i 32]
+      (vswap! tree hmsg/insert i i))
+    (ha/<?? (tree/flush-tree @tree (kons/->KonserveBackend store nil)))
+    (testing "that GC doesn't remove anything if there are no garbage nodes."
+      (let [all-storage-keys (async/<!! (async/into [] (k/keys store)))
+            removed (volatile! #{})
+            scratch (gck/->KonserveGCScratch (async/<!! (mem/new-mem-store)) (Date.))
+            delete-fn (fn [k]
+                        (async/go
+                          (vswap! removed conj k)
+                          (async/<! (k/dissoc store k))))]
+        (async/<!! (gc/trace-gc! scratch [@tree] (k/keys store) delete-fn))
+        (is (empty? @removed))
+        (is (= (set all-storage-keys) (async/<!! (async/into #{} (k/keys store)))))))
+    (testing "that GC removed garbage nodes"
+      (dotimes [i 32]
+        (vswap! tree hmsg/insert (+ i 32) (+ i 32)))
+      (dotimes [i 32]
+        (vswap! tree hmsg/delete i))
+      (ha/<?? (tree/flush-tree @tree (kons/->KonserveBackend store nil)))
+      (let [live-nodes (loop [nodes [@tree]
+                              live #{}]
+                         (if-let [node (first nodes)]
+                           (let [node (if (tree/resolved? node) node (tree/<?-resolve node))
+                                 live (if-let [addr (async/poll! (:storage-addr node))]
+                                        (conj live (:konserve-key addr))
+                                        live)]
+                             (if (tree/index-node? node)
+                               (recur (into (subvec nodes 1) (:children node)) live)
+                               (recur (subvec nodes 1) live)))
+                           live))
+            removed (volatile! #{})
+            scratch (gck/->KonserveGCScratch (async/<!! (mem/new-mem-store)) (Date.))
+            delete-fn (fn [k]
+                        (async/go
+                          (vswap! removed conj k)
+                          (async/<! (k/dissoc store k))))]
+        (async/<!! (gc/trace-gc! scratch [@tree] (k/keys store) delete-fn))
+        (is (seq @removed))
+        (is (= live-nodes (async/<!! (async/into #{} (k/keys store))))))
+      (testing "that GC leaves a usable tree in storage"
+        (let [tree2 (ha/<?? (kons/create-tree-from-root-key store (kons/get-root-key @tree)))
+              iter (hmsg/lookup-fwd-iter tree2 0)]
+          (dotimes [i 32]
+            (is (= (+ i 32) (ha/<?? (hmsg/lookup tree2 (+ i 32))))))
+          (is (= (map #(vector % %) (range 32 64)) (seq iter))))))))


### PR DESCRIPTION
Based partially on https://github.com/datacrypt-project/hitchhiker-tree/pull/24. Rewritten to primarily use core.async.

Would need something like https://github.com/replikativ/konserve/pull/29 to iterate keys in the store.

* src/hitchhiker/tree/konserve.cljc (create-id): new function; prepends
  the current timestamp as hex to the UUID key.
  (KonserveBackend.-write-node): use create-id to generate the storage ID.
* src/hitchhiker/tree/tracing-gc/konserve.cljc: new namespace.
* src/hitchhiker/tree/tracing-gc.cljc: new namespace.
* .gitignore: ignore IntelliJ files.
* project.clj: update konserve to 0.6.0-SNAPSHOT.