### PR TITLE
Fix insertion order bug with IKeyCompare extension

### DIFF
--- a/src/hitchhiker/tree.cljc
+++ b/src/hitchhiker/tree.cljc
@@ -157,8 +157,6 @@
                (next set))
         (first set)))))
 
-(def empty-sorted-map-by-compare (sorted-map-by c/-compare))
-
 (defrecord DataNode [children storage-addr cfg *last-key-cache]
 
   n/IDataNode
@@ -192,8 +190,8 @@
     (let [data-b (:data-b cfg)]
       (loop [children children
              i 0
-             left empty-sorted-map-by-compare
-             right empty-sorted-map-by-compare]
+             left (sorted-map-by c/-compare)
+             right (sorted-map-by c/-compare)]
         (if-let [child (first children)]
           (if (< i data-b)
             (recur (next children)
@@ -335,7 +333,7 @@
   [{:keys [cfg] :as tree} k v]
   (ha/go-try
    (let [path (ha/<? (lookup-path tree k))
-         {:keys [children] :or {children empty-sorted-map-by-compare}} (peek path)
+         {:keys [children] :or {children (sorted-map-by c/-compare)}} (peek path)
          updated-data-node (data-node (assoc children k v)
                                       cfg)]
      (loop [node updated-data-node
@@ -375,7 +373,7 @@
   (ha/go-try
    (let [path (ha/<? (lookup-path tree key)) ;; don't care about the found key or its index
          {:keys [children]
-          :or {children empty-sorted-map-by-compare}} (peek path)
+          :or {children (sorted-map-by c/-compare)}} (peek path)
          updated-data-node (data-node (dissoc children key)
                                       cfg)]
      (loop [node updated-data-node
@@ -429,7 +427,7 @@
   [cfg & kvs]
   (ha/go-try
    (loop [[[k v] & r] (partition 2 kvs)
-          t (data-node empty-sorted-map-by-compare
+          t (data-node (sorted-map-by c/-compare)
                        cfg)]
      (if k
        (recur r (ha/<? (insert t k v)))


### PR DESCRIPTION
As noted in replikativ/datahike#122 and replikativ/datahike#258 there
are cases where the insertion order of elements into trees differs
from the order used during lookups. This causes issues where items can
be present in the tree, but not findable via the lookup functions.

The cause is def'ing empty-sorted-map-by-compare at namespace load. When
any later extensions to the IKeyCompare protocol are made, they alter
the -compare var (normal behavior of Clojure protocols). This means
Clojure code calling -compare sees the new behavior, but the
empty-sorted-map-by-compare has already instantiated a PersistentTreeMap
with the -compare method as defined at namespace load, ultimately only
what was defined in hitchhiker.tree.key-compare.

Datahike specifically extended IKeyCompare to handle vectors, since its
indices are vectors of various arrangements of datom components. In
particular this behavior is noticeable in the avet index, where you try
to locate an entity by attribute and value. The values are highly
sensitive to IKeyCompare's ordering, since they have far more variable
types than the attributes or entity IDs.

It may make sense for hitchhiker-tree to also handle collection sorting
out-of-box, since lack of this is makes sorting of collections with
elements IKeyCompare supports to sort differently than the raw values
do.

Looking at the upstream hitchhiker-tree [1], they were calling
sorted-map-by for each node creation, so I'm guessing it's not too
performance sensitive.

[1]
https://github.com/datacrypt-project/hitchhiker-tree/blob/f7d0f926541d7cb31fac11c2d2245c5bac451b86/src/hitchhiker/tree/core.cljc#L618