### PR TITLE
Fix sort by insertion timestamp

### DIFF
--- a/src/hitchhiker/tree/bootstrap/konserve.cljc
+++ b/src/hitchhiker/tree/bootstrap/konserve.cljc
@@ -138,9 +138,9 @@
                              (vec op-buf)
                              cfg))
           'hitchhiker.tree.messaging.InsertOp
-          msg/map->InsertOp
+          #(msg/->InsertOp (:key %) (:value %) (or (:ts %) 0))
           'hitchhiker.tree.messaging.DeleteOp
-          msg/map->DeleteOp
+          #(msg/->DeleteOp (:key %) (or (:ts %) 0))
           'hitchhiker.tree.Config
           tree/map->Config
 

--- a/src/hitchhiker/tree/messaging.cljc
+++ b/src/hitchhiker/tree/messaging.cljc
@@ -173,7 +173,7 @@
 
 (defn current-timestamp []
   #?(:clj (System/currentTimeMillis)
-    :cljs (.getTime (js/Date.))))
+     :cljs (.getTime (js/Date.))))
 
 (defn insert
   [tree key value]

--- a/src/hitchhiker/tree/op.cljc
+++ b/src/hitchhiker/tree/op.cljc
@@ -6,6 +6,7 @@
      (more memory but faster results for repeat queries)")
 
 (defprotocol IOperation
-  (-affects-key [op] "Which key this affects--currently must be a single key")
-  (-apply-op-to-coll [op coll] "Applies the operation to the collection")
+  (-insertion-ts [op] "Returns totally ordered timestamp at which this operation has been created.")
+  (-affects-key [op] "Which key this affects--currently must be a single key.")
+  (-apply-op-to-coll [op coll] "Applies the operation to the collection.")
   (-apply-op-to-tree [op tree] "Applies the operation to the tree. Returns go-block."))


### PR DESCRIPTION
Adds timestamp to operations so that they are applied to the tree in their creation time order.