### PR TITLE
Adds the compare deref fix and bumps hitchhiker-tree version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>io.replikativ</groupId>
   <artifactId>hitchhiker-tree</artifactId>
-  <version>0.1.10</version>
+  <version>0.1.11</version>
   <name>konserve</name>
   <description>A Hitchhiker Tree Library</description>
   <dependencies>

--- a/src/hitchhiker/tree.cljc
+++ b/src/hitchhiker/tree.cljc
@@ -157,7 +157,12 @@
                (next set))
         (first set)))))
 
-(def empty-sorted-map-by-compare (sorted-map-by c/-compare))
+;; To allow extensions of the comparison protocol after loading the
+;; hitchhiker-tree we deref the comparator at invocation time. An alternative of
+;; constructing the empty sets as non-singletons during runtime was explored in
+;; https://github.com/replikativ/hitchhiker-tree/pull/22, but performed worse in
+;; the benchmarks.
+(def empty-sorted-map-by-compare (sorted-map-by (fn [a b] (@#'c/-compare a b))))
 
 (defrecord DataNode [children storage-addr cfg *last-key-cache]
 


### PR DESCRIPTION
Adds the compare deref fix.
Goes directly to master for release.

Fix replikativ/datahike#122 and replikativ/datahike#258.

Addresses the same issue as
https://github.com/replikativ/hitchhiker-tree/pull/22, but with smaller
performance penalty on JVM benchmarks. Thanks @ajoberstar for tracking the issue
down!